### PR TITLE
systemd: speedup monitor command 2x

### DIFF
--- a/src/dron/common.py
+++ b/src/dron/common.py
@@ -48,6 +48,11 @@ class UnitState:
 
 
 @dataclass
+class SystemdUnitState(UnitState):
+    dbus_properties: Any  # seems like keeping this around massively speeds up dbus access...
+
+
+@dataclass
 class LaunchdUnitState(UnitState):
     # NOTE: can legit be str (e.g. if unit was never ran before)
     last_exit_code: str | None

--- a/src/dron/launchd.py
+++ b/src/dron/launchd.py
@@ -258,14 +258,14 @@ def launchd_state(*, with_body: bool) -> Iterator[LaunchdUnitState]:
                 periodic_schedule = extras.get('run interval')
                 calendal_schedule = 'com.apple.launchd.calendarinterval' in unwrap(all_props)
 
-                schedule: str | None = None
+                schedule: str | None
                 if periodic_schedule is not None:
                     schedule = 'every ' + periodic_schedule
                 elif calendal_schedule:
                     # TODO parse properly
                     schedule = 'calendar'
                 else:
-                    # NOTE: seems like keepalive attribute isn't present in launcd dumpstate output
+                    # NOTE: seems like keepalive attribute isn't present in launchd dumpstate output
                     schedule = 'always'
 
                 yield LaunchdUnitState(


### PR DESCRIPTION
mainly by reusing dbug property accessor (not 100% sure why it helps but it works)

before
```
$ hyperfine 'dron monitor --once'
Benchmark 1: dron monitor --once
  Time (mean ± σ):      1.993 s ±  0.066 s    [User: 0.976 s, System: 0.113 s]
  Range (min … max):    1.926 s …  2.118 s    10 runs
```

after
```
$ hyperfine 'dron monitor --once'
Benchmark 1: dron monitor --once
  Time (mean ± σ):     913.7 ms ±  71.9 ms    [User: 471.3 ms, System: 50.1 ms]
  Range (min … max):   850.3 ms … 1077.6 ms    10 runs
```